### PR TITLE
Update Kotlin Multiplatform version and Gradle version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,8 @@
         "webPort": "6080",
         "vncPort": "5901"
     }
+  },
+  "tasks": {
+    "build": "./gradlew build"
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("multiplatform") version "1.8.0"
+    kotlin("multiplatform") version "2.1.0-Beta2"
 }
 
 version = "1.0-SNAPSHOT"


### PR DESCRIPTION
Update Kotlin Multiplatform plugin version and add build task to devcontainer configuration.

* Update the Kotlin Multiplatform plugin version to "2.1.0-Beta2" in `build.gradle.kts`.
* Add a build task to the `.devcontainer/devcontainer.json` file to run `./gradlew build`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/getpythoncode-help/datasciencecoursera?shareId=9188f11a-24a3-4f01-9b0b-a06bfabfc8d5).